### PR TITLE
Fix CLS Needs statement

### DIFF
--- a/GameData/SpaceDockReBoxed/Parts/NanoDock/NanoDock.cfg
+++ b/GameData/SpaceDockReBoxed/Parts/NanoDock/NanoDock.cfg
@@ -20,8 +20,8 @@
 	category = Utility
 	subcategory = 0
 	title = SSSYE NanoDock
-	manufacturer = SpaceShip�Yard Enterprises
-	description = In a joint venture with Sphero-Hedron Engineering Dynamics, SpaceShip� Yard Enterprises have overcome the intial problem of getting Space Docks into space. This basic, lightweight solution is everthing the budding Space Konstructor could ever need to start their space fleet! Comes with built-in lights.
+        manufacturer = SpaceShip²Yard Enterprises
+        description = In a joint venture with Sphero-Hedron Engineering Dynamics, SpaceShip² Yard Enterprises have overcome the intial problem of getting Space Docks into space. This basic, lightweight solution is everthing the budding Space Konstructor could ever need to start their space fleet! Comes with built-in lights.
 
 	// attachment rules: stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 1,0,1,1,0
@@ -121,9 +121,9 @@
 		attachPartSndPath = KIS/Sounds/attachPart
 		detachPartSndPath= KIS/Sounds/detachPart
  	}   
-	MODULE
+	MODULE:NEEDS[ConnectedLivingSpace]
 	{
-		name = ModuleConnectedLivingSpace:NEEDS[ConnectedLIvingSpace]
+        	name = ModuleConnectedLivingSpace
 		passable = true
 		passablenodes = topNode, bottomNode, loadNode, storageNode1, storageNode2
 		impassablenodes = buildNode

--- a/GameData/SpaceDockReBoxed/Parts/Spacedock_Large/Spacedock_LargeS2.cfg
+++ b/GameData/SpaceDockReBoxed/Parts/Spacedock_Large/Spacedock_LargeS2.cfg
@@ -63,9 +63,9 @@ PART
 		detachPartSndPath= KIS/Sounds/detachPart
 	}
 
-	MODULE
+    MODULE:NEEDS[ConnectedLivingSpace]
 	{
-		name = ModuleConnectedLivingSpace:NEEDS[ConnectedLIvingSpace]
+    		name = ModuleConnectedLivingSpace
 		passable = true
 		passablenodes = top, bottom
 		impassablenodes = innerStarboard, innerPort, outerStarboard, outerPort, topPort, topStarboard, bottomPort, bottomStarboard

--- a/GameData/SpaceDockReBoxed/Parts/Spacedock_Large/Spacedock_LargeS3.cfg
+++ b/GameData/SpaceDockReBoxed/Parts/Spacedock_Large/Spacedock_LargeS3.cfg
@@ -63,9 +63,9 @@ PART
 		detachPartSndPath= KIS/Sounds/detachPart
 	}
 	
-	MODULE
+    MODULE:NEEDS[ConnectedLivingSpace]
 	{
-		name = ModuleConnectedLivingSpace:NEEDS[ConnectedLIvingSpace]
+        name = ModuleConnectedLivingSpace
 		passable = true
 		passablenodes = top, bottom
 		impassablenodes = innerStarboard, innerPort, outerStarboard, outerPort, topPort, topStarboard, bottomPort, bottomStarboard

--- a/GameData/SpaceDockReBoxed/Parts/Spacedock_Medium/Spacedock_Medium_S2.cfg
+++ b/GameData/SpaceDockReBoxed/Parts/Spacedock_Medium/Spacedock_Medium_S2.cfg
@@ -63,9 +63,9 @@ PART
 		detachPartSndPath= KIS/Sounds/detachPart
 	}
    
-	MODULE
+	MODULE:NEEDS[ConnectedLivingSpace]
 	{
-		name = ModuleConnectedLivingSpace:NEEDS[ConnectedLIvingSpace]
+		name = ModuleConnectedLivingSpace
 		passable = true
 		passablenodes = top, bottom
 		impassablenodes = innerStarboard, innerPort, outerStarboard, outerPort, topPort, topStarboard, bottomPort, bottomStarboard

--- a/GameData/SpaceDockReBoxed/Parts/Spacedock_Medium/Spacedock_Medium_S3.cfg
+++ b/GameData/SpaceDockReBoxed/Parts/Spacedock_Medium/Spacedock_Medium_S3.cfg
@@ -63,9 +63,9 @@ PART
 		detachPartSndPath= KIS/Sounds/detachPart
 	}
 
-	MODULE
+	MODULE:NEEDS[ConnectedLivingSpace]
 	{
-		name = ModuleConnectedLivingSpace:NEEDS[ConnectedLIvingSpace]
+		name = ModuleConnectedLivingSpace
 		passable = true
 		passablenodes = top, bottom
 		impassablenodes = innerStarboard, innerPort, outerStarboard, outerPort, topPort, topStarboard, bottomPort, bottomStarboard

--- a/GameData/SpaceDockReBoxed/Parts/Spacedock_Small/Spacedock_Small_S2.cfg
+++ b/GameData/SpaceDockReBoxed/Parts/Spacedock_Small/Spacedock_Small_S2.cfg
@@ -64,9 +64,9 @@ PART
 	}
 
 
-	MODULE
+	MODULE:NEEDS[ConnectedLivingSpace]
 	{
-		name = ModuleConnectedLivingSpace:NEEDS[ConnectedLIvingSpace]
+        name = ModuleConnectedLivingSpace
 		passable = true
 		passablenodes = top, bottom
 		impassablenodes = innerStarboard, innerPort, outerStarboard, outerPort, topPort, topStarboard, bottomPort, bottomStarboard

--- a/GameData/SpaceDockReBoxed/Parts/Spacedock_Small/Spacedock_Small_S3.cfg
+++ b/GameData/SpaceDockReBoxed/Parts/Spacedock_Small/Spacedock_Small_S3.cfg
@@ -63,9 +63,9 @@ PART
 		detachPartSndPath= KIS/Sounds/detachPart
 	}
 	
-	MODULE
+	MODULE:NEEDS[ConnectedLivingSpace]
 	{
-		name = ModuleConnectedLivingSpace:NEEDS[ConnectedLIvingSpace]
+        name = ModuleConnectedLivingSpace
 		passable = true
 		passablenodes = top, bottom
 		impassablenodes = innerStarboard, innerPort, outerStarboard, outerPort, topPort, topStarboard, bottomPort, bottomStarboard


### PR DESCRIPTION
:NEEDS[ConnectedLivingSpace] located in wrong spot.  It must be on the containing MODULE keyword.  Located where it was the :NEEDS[] became part of the module name and caused an error to be thrown.

Also minor text cleanup in one part to match style of others.